### PR TITLE
[ADD] 홈탭 단어 관련 뷰모델 데이터 추가

### DIFF
--- a/FancyMouse/Presentation/Home/ViewModel/HomeWordCellViewModel.swift
+++ b/FancyMouse/Presentation/Home/ViewModel/HomeWordCellViewModel.swift
@@ -6,3 +6,9 @@
 //
 
 import Foundation
+
+struct HomeWordCell {
+    let title: String
+    let meaning: String
+    let status: MemorizationStatus
+}

--- a/FancyMouse/Presentation/Home/ViewModel/MemorizationViewModel.swift
+++ b/FancyMouse/Presentation/Home/ViewModel/MemorizationViewModel.swift
@@ -6,3 +6,14 @@
 //
 
 import Foundation
+
+struct MemorizationStatus {
+    enum Status {
+        case unknown
+        case memorizing
+        case complete
+    }
+
+    let title: String
+    let status: Status
+}


### PR DESCRIPTION
<b>폴더링 수정 후 홈 탭 단어셀 관련 뷰모델 데이터 추가했습니다.</b>

<br>

- 폴더링
<img src="https://user-images.githubusercontent.com/70688424/151711226-a08d0b20-c52b-4f4d-9a7f-0cfcbe16d08f.png" width = "30%">

Home폴더에서 View와 ViewModel 폴더로 분리했습니다.

<br>

- 뷰모델

<img src="https://user-images.githubusercontent.com/70688424/151711070-ba6e5fba-5d9f-46b6-a6e7-198fc31b72bd.png" width = "50%">

암기/미암기 뷰 관련 뷰모델
```
struct MemorizationStatus {
    enum Status {
        case unknown
        case memorizing
        case complete
    }

    let title: String
    let status: Status
}
```

단어 셀 관련 뷰모델

```
struct HomeWordCell {
    let title: String
    let meaning: String
    let status: MemorizationStatus
}
```

수정할 것들 마구마구 지적해주세요!!